### PR TITLE
Remove extra * in attributes guide

### DIFF
--- a/public/docs/ts/latest/guide/attribute-directives.jade
+++ b/public/docs/ts/latest/guide/attribute-directives.jade
@@ -355,7 +355,7 @@ figure.image-display
   In all previous bindings, the directive or component property was a binding ***source***.
   A property is a *source* if it appears in the template expression to the ***right*** of the (=).
   
-  A property is a *target* when it appears to the ***left** of the (=) ...
+  A property is a *target* when it appears to the **left** of the (=) ...
   as it is does when we bind to the `myHighlight` property of the `HighlightDirective`, 
 +makeExample('attribute-directives/ts/app/app.component.html','span')(format=".")
 :marked


### PR DESCRIPTION
There is an extra \* in the Input Properties appendix that needs removing
